### PR TITLE
Fix visitor hook lint error

### DIFF
--- a/app/hooks/use-visitor.ts
+++ b/app/hooks/use-visitor.ts
@@ -5,9 +5,12 @@ import { useMutation } from '@tanstack/react-query';
 import { load } from '@fingerprintjs/fingerprintjs';
 
 export function useVisitor() {
-    const [visitorId, setVisitorId] = useState<string | null>(null);
+    const [visitorId, setVisitorId] = useState<string | null>(() => {
+        if (typeof window === 'undefined') return null;
+        return localStorage.getItem('visitor_id');
+    });
 
-    const mutation = useMutation({
+    const { mutate, data, isPending, isError, error } = useMutation({
         mutationFn: async (visitorId: string) => {
             const res = await fetch(`/api/visitor/${visitorId}`, {
                 method: 'POST',
@@ -25,28 +28,32 @@ export function useVisitor() {
     });
 
     useEffect(() => {
-        const sessionVisitorId = localStorage.getItem('visitor_id');
-        if (sessionVisitorId) {
-            setVisitorId(sessionVisitorId);
-            return;
-        }
+        if (visitorId) return;
+
+        let cancelled = false;
+
         (async () => {
             try {
                 const fp = await load();
                 const { visitorId } = await fp.get();
+                if (cancelled) return;
                 setVisitorId(visitorId);
-                mutation.mutate(visitorId);
-            } catch (error) {
+                mutate(visitorId);
+            } catch {
                 console.error('Error fetching visitor ID');
             }
         })();
-    }, []);
+
+        return () => {
+            cancelled = true;
+        };
+    }, [mutate, visitorId]);
 
     return {
         visitorId,
-        visitorData: mutation.data,
-        isPending: mutation.isPending,
-        isError: mutation.isError,
-        error: mutation.error,
+        visitorData: data,
+        isPending,
+        isError,
+        error,
     };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Move cached visitor ID lookup into the `useState` initializer to avoid synchronous state updates inside `useEffect`.
- Destructure mutation state so the effect dependency list is explicit and lint-clean.

### Environment setup
- Installed Bun for the `bun.lock` based project.
- Installed dependencies with `bun install`.
- Created ignored local `.env.local` placeholder values for Supabase so Next can build and start in this VM.
- Started the dev server with `bun run dev` at `http://localhost:3000`.

### Walkthrough
[next_dev_routes_walkthrough.mp4](https://cursor.com/agents/bc-39093c11-39a4-43c1-bbf4-c23e0d61affa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnext_dev_routes_walkthrough.mp4)
[Life page loaded](https://cursor.com/agents/bc-39093c11-39a4-43c1-bbf4-c23e0d61affa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flife_page_loaded.webp)

### Testing
- `bun run lint` passes with existing warnings.
- `bun run build` passes with local placeholder Supabase values.
- `curl -I http://localhost:3000` returns `HTTP/1.1 200 OK`.
- Manual browser walkthrough loaded Home, Projects, Writing, and Life without visible Next.js error overlays.

### Known local limitation
- Docker and Supabase CLI are not installed on this VM, so the included local Supabase stack cannot be started here. Supabase-backed API writes require real Supabase credentials or a local Supabase service.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39093c11-39a4-43c1-bbf4-c23e0d61affa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39093c11-39a4-43c1-bbf4-c23e0d61affa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

